### PR TITLE
usb_gadget: increase CD-ROM limit to LBA limit

### DIFF
--- a/drivers/usb/gadget/function/storage_common.c
+++ b/drivers/usb/gadget/function/storage_common.c
@@ -249,8 +249,8 @@ int fsg_lun_open(struct fsg_lun *curlun, const char *filename)
 	min_sectors = 1;
 	if (curlun->cdrom) {
 		min_sectors = 300;	/* Smallest track is 300 frames */
-		if (num_sectors >= 256*60*75) {
-			num_sectors = 256*60*75 - 1;
+		if (num_sectors >= 0xFFFFDF) {
+			num_sectors = 0xFFFFDF - 1;
 			LINFO(curlun, "file too big: %s\n", filename);
 			LINFO(curlun, "using only first %d blocks\n",
 					(int) num_sectors);


### PR DESCRIPTION
Allows DriveDroid to mount larger images. New limit is 8GB, up from 2.2GB.